### PR TITLE
remove the double brackets (( )) in link

### DIFF
--- a/index.md
+++ b/index.md
@@ -54,7 +54,7 @@ If you are interested in joining our initiative or exploring a collaboration, pl
         <img src="/images/posts/CAPRI-7th-evaluation-meeting.jpg">
 </figure>
 
-More info about this meeting can be found under [events]((/events)) and a blog is available [here](https://bioexcel.eu/7th-capri-evaluation-meeting/).
+More info about this meeting can be found under [events](/events) and a blog is available [here](https://bioexcel.eu/7th-capri-evaluation-meeting/).
 
 
 <hr>


### PR DESCRIPTION
The link didn't work because it was [events]((/events)), this is to change it to: [events](/events), which should work well.